### PR TITLE
Fix buzz time

### DIFF
--- a/backend/api/buzzer.go
+++ b/backend/api/buzzer.go
@@ -76,8 +76,8 @@ func Buzz(client *Client, event *Event) GameError {
 	if !ok {
 		return GameError{code: PLAYER_NOT_FOUND}
 	}
-	latencyMilliseconds := time.Millisecond * time.Duration(player.Latency)
-	latencyTime := time.Now().UTC().Add(-latencyMilliseconds).UnixMilli()
+	latency := time.Millisecond * time.Duration(player.Latency)
+	latencyTime := time.Now().UTC().Add(-latency).UnixMilli()
 	if len(room.Game.Buzzed) == 0 {
 		room.Game.Buzzed = append(room.Game.Buzzed, buzzed{
 			ID:   event.ID,

--- a/backend/api/data.go
+++ b/backend/api/data.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 )
 
 func mergeGame(game *game, newData *game) {
@@ -28,6 +29,7 @@ func NewData(client *Client, event *Event) GameError {
 		return storeError
 	}
 	copyRound := room.Game.Round
+	copyTitle := room.Game.Title
 	newData := game{}
 	rawData, err := json.Marshal(event.Data)
 	if err != nil {
@@ -40,8 +42,9 @@ func NewData(client *Client, event *Event) GameError {
 	mergeGame(room.Game, &newData)
 	setTick(client, event)
 
-	if copyRound != newData.Round {
+	if copyRound != newData.Round || copyTitle != newData.Title {
 		room.Game.Buzzed = []buzzed{}
+		room.Game.RoundStartTime = time.Now().UTC().UnixMilli()
 		message, err := NewSendClearBuzzers()
 		if err != nil {
 			return GameError{code: SERVER_ERROR, message: fmt.Sprint(err)}

--- a/backend/api/game.go
+++ b/backend/api/game.go
@@ -78,6 +78,7 @@ type game struct {
 	FinalRound2       []finalRound                 `json:"final_round_2"`
 	FinalRoundTimers  []int                        `json:"final_round_timers"`
 	Tick              int64                        `json:"tick"`
+	RoundStartTime    int64                        `json:"round_start_time"`
 }
 
 func setTick(client *Client, event *Event) GameError {
@@ -127,6 +128,7 @@ func NewGame(roomCode string) room {
 			HideFirstRound: false,
 			Round:          0,
 			Tick: time.Now().UTC().UnixMilli(),
+			RoundStartTime: time.Now().UTC().UnixMilli(),
 		},
 	}
 }

--- a/components/BuzzerTable.jsx
+++ b/components/BuzzerTable.jsx
@@ -1,0 +1,43 @@
+import { useTranslation } from 'react-i18next';
+
+const BuzzerTable = ({ game }) => {
+  const { t } = useTranslation();
+
+  if (!game?.buzzed) return null;
+
+  return (
+    <table className="w-full">
+      <thead>
+        <tr className="text-left text-foreground">
+          <th>#</th>
+          <th>{t('team')}</th>
+          <th>{t('player')}</th>
+          <th>{t('time')}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {game.buzzed.length > 0 && game.buzzed.map((buzz, index) => (
+          <tr key={`buzzer-${buzz.id}-${index}`}>
+            <td id={`playerBuzzed${index}NumberText`} className="text-left text-foreground">
+              {t('number', { count: index + 1 })}
+            </td>
+
+            <td id={`playerBuzzed${index}TeamNameText`} className="text-left text-foreground">
+              {game.teams[game.registeredPlayers[buzz.id]?.team]?.name}
+            </td>
+
+            <td id={`playerBuzzed${index}NameText`} className="text-left text-foreground">
+              {game.registeredPlayers[buzz.id]?.name}
+            </td>
+
+            <td id={`playerBuzzer${index}BuzzerTimeText`} className="text-left text-foreground">
+              {((buzz.time - game.round_start_time) / 1000).toFixed(2)}s
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+};
+
+export default BuzzerTable;

--- a/components/admin.js
+++ b/components/admin.js
@@ -9,6 +9,7 @@ import CSVLoader from "./Admin/csv-loader";
 import { Buffer } from "buffer";
 import { handleCsvFile, handleJsonFile } from "utils/files";
 import { ERROR_CODES } from "i18n/errorCodes";
+import BuzzerTable from "./BuzzerTable";
 
 function debounce(callback, wait = 400) {
   let timeout;
@@ -1050,32 +1051,7 @@ export default function Admin(props) {
                         </div>
                         <hr />
                         <div className="flex-grow">
-                          {game.buzzed.map((x, i) => (
-                            <div key={`buzzer-${x.id}-${i}`} className="flex flex-row space-x-5 justify-center">
-                              <p id={`playerBuzzed${i}NameText`} className="text-foreground">
-                                {t("number", { count: i + 1 })}.{" "}
-                                {game.registeredPlayers[x.id]?.name}
-                              </p>
-                              <p
-                                className="text-foreground"
-                                id={`playerBuzzed${i}TeamNameText`}
-                              >
-                                {t("team")}:{" "}
-                                {
-                                  game.teams[game.registeredPlayers[x.id]?.team]
-                                    ?.name
-                                }
-                              </p>
-                              <p
-                                className="text-foreground"
-                                id={`playerBuzzer${i}BuzzerTimeText`}
-                              >
-                                {t("time")}:{" "}
-                                {((x.time - game.round_start_time) / 1000).toFixed(2)}{" "}
-                                {t("seconds")}
-                              </p>
-                            </div>
-                          ))}
+                          <BuzzerTable game={game} />
                         </div>
                       </div>
                     </div>

--- a/components/admin.js
+++ b/components/admin.js
@@ -1071,7 +1071,7 @@ export default function Admin(props) {
                                 id={`playerBuzzer${i}BuzzerTimeText`}
                               >
                                 {t("time")}:{" "}
-                                {(((x.time - game.tick) / 1000) % 60).toFixed(2)}{" "}
+                                {((x.time - game.round_start_time) / 1000).toFixed(2)}{" "}
                                 {t("seconds")}
                               </p>
                             </div>

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -72,6 +72,7 @@
   "Points": "Points",
   "Buzzer Order": "Buzzer Order",
   "players": "players",
+  "player": "Player",
   "Clear Buzzers": "Clear Buzzers",
   "Changing rounds also clears buzzers": "Changing rounds also clears buzzers",
   "Back To": "Back To",
@@ -121,6 +122,7 @@
   "Format Guide": "Format Guide",
   "Each row follows this pattern. Points must be numbers.": "Each row follows this pattern. Points must be numbers.",
   "You have been blindfolded...": "You have been blindfolded...",
+  "Reset Mistakes": "Reset Mistakes",
   "errors": {
     "room_not_found": "Room not found",
     "host_quit": "Host quit the game",

--- a/public/locales/et/translation.json
+++ b/public/locales/et/translation.json
@@ -72,6 +72,7 @@
     "Points": "Punktid",
     "Buzzer Order": "M\u00e4rguande J\u00e4rjekord",
     "players": "m\u00e4ngjad",
+    "player": "Mängija",
     "Clear Buzzers": "T\u00fchjenda m\u00e4rguanded",
     "Changing rounds also clears buzzers": "Vooru vahetust t\u00fchjendab m\u00e4rguanded",
     "Back To": "Tagasi",
@@ -121,6 +122,7 @@
     "Format Guide": "Vormingu juhend",
     "Each row follows this pattern. Points must be numbers.": "Iga rida järgib seda vormingut. Punktid peavad olema numbrid",
     "You have been blindfolded...": "Sind on pimestatud...",
+    "Reset Mistakes": "Lähtesta vead",
     "errors": {
         "room_not_found": "Mängu ei leitud",
         "host_quit": "Mängu juht lahkus mängust",


### PR DESCRIPTION
**Description:**
Front-end was dividing/updating/subtracting the buzz time on buzzer order on each state change e.g. when user board visibility is changed. This caused the buzz time to go into negative seconds.

**Changes made:**
f15daa7445f77fbbc79abbd38b7a157bcc128b71 fixed linter error: `var latencyMilliseconds is of type time.Duration; don't use unit-specific suffix "Milliseconds" (ST1011)`
b56875c0c41df995f268954505fe12b49a63f689 fixed the main issue and added RoundStartTime to game obj
ec9085c3e3dd31b82123df3bac57564f97f4de1c refactors admin.js buzzer order to separate component BuzzerTable.jsx
b83b1444d9c9620d5f58d59b1dafc79dbd7f9d67 adds missing translations (en & et)