### PR TITLE
fix(goroutine): add missing loop into gameTimeout

### DIFF
--- a/backend/api/game.go
+++ b/backend/api/game.go
@@ -130,5 +130,6 @@ func NewGame(roomCode string) room {
 			Tick: time.Now().UTC().UnixMilli(),
 			RoundStartTime: time.Now().UTC().UnixMilli(),
 		},
+        cleanup: make(chan struct{}),
 	}
 }

--- a/backend/api/room.go
+++ b/backend/api/room.go
@@ -73,9 +73,9 @@ func (r *room) gameTimeout() error {
 	for {
 		select {
 		case <-ticker.C:
-            timeout := time.Duration(cfg.roomTimeoutSeconds) * time.Second
-            timeoutAgo := time.Now().UTC().Add(-timeout).UnixMilli()
-            if r.Game.Tick > 0 && r.Game.Tick < timeoutAgo {
+			timeout := time.Duration(cfg.roomTimeoutSeconds) * time.Second
+			timeoutAgo := time.Now().UTC().Add(-timeout).UnixMilli()
+			if r.Game.Tick > 0 && r.Game.Tick < timeoutAgo {
 				log.Println("clearing room, no activity for", cfg.roomTimeoutSeconds, "seconds:", r.Game.Room)
 				message, err := NewSendQuit()
 				if err != nil {
@@ -92,7 +92,7 @@ func (r *room) gameTimeout() error {
 				return nil
 			}
 		// If host quits, remove loop
-		case <- r.cleanup:
+		case <-r.cleanup:
 			return nil
 		}
 	}

--- a/backend/api/session.go
+++ b/backend/api/session.go
@@ -56,6 +56,8 @@ func quitHost(room *room, event *Event) GameError {
 	if room.Hub.stop != nil {
 		room.Hub.stop <- true
 	}
+	// Signal cleanup channel to stop the room timeout goroutine
+	close(room.cleanup)
 	// Remove room
 	s.deleteRoom(event.Room)
 	s.deleteLogo(event.Room)

--- a/backend/main.go
+++ b/backend/main.go
@@ -12,12 +12,12 @@ import (
 )
 
 var cfg = struct {
-	addr  string
-	store string
+	addr               string
+	store              string
 	roomTimeoutSeconds int64
 }{
-	addr: ":8080",
-	store: "memory",
+	addr:               ":8080",
+	store:              "memory",
 	roomTimeoutSeconds: 86400,
 }
 


### PR DESCRIPTION
Fixes #144

- add roomTimeoutSeconds env var
- default timeout to 1 day / 86400s, felt like hours wasn't as customizable (if you wanted to do a 30min timeout lets say)
- fix staticcheck SA4001 warning, `cfg.addr == *&cfg.addr` (correct me if I'm wrong)
- fix "quitted" rooms still looping by adding a room cleanup channel, if the host quits, the room timeout will still loop, even though theres no room

But **in short:** the gameTimeout() function was missing the for{} wrapper, so it only ran once