### PR TITLE
fix(buzzer) include check for when player refreshes page and they already buzzed

### DIFF
--- a/src/components/BuzzerPage.jsx
+++ b/src/components/BuzzerPage.jsx
@@ -163,7 +163,7 @@ export default function BuzzerPage(props) {
 
                 {/* Buzzer Section TODO replace with function*/}
                 <div className="w-full text-center">
-                  {buzzed ? (
+                  {buzzed || game.buzzed.map((a) => a.id).includes(props.id) ? (
                     <Image id="buzzerButtonPressed" width={500} height={200} alt="Buzzer Button" src="/buzzed.svg" />
                   ) : (
                     <Image

--- a/src/components/BuzzerPage.jsx
+++ b/src/components/BuzzerPage.jsx
@@ -164,7 +164,14 @@ export default function BuzzerPage(props) {
                 {/* Buzzer Section TODO replace with function*/}
                 <div className="w-full text-center">
                   {buzzed || game.buzzed.map((a) => a.id).includes(props.id) ? (
-                    <Image id="buzzerButtonPressed" width={500} height={200} alt="Buzzer Button" src="/buzzed.svg" />
+                    <Image
+                      className="inline-block w-1/2"
+                      id="buzzerButtonPressed"
+                      width={500}
+                      height={200}
+                      alt="Buzzer Button"
+                      src="/buzzed.svg"
+                    />
                   ) : (
                     <Image
                       id="buzzerButton"


### PR DESCRIPTION
- fix(buzzer) when a player refreshes the page `buzzed` is cleared, so we need to check the buzzed object for the players id

- fix(css) styling for buzzer before and after press is consistent