### PR TITLE
fix(backend) Fix potential send to closed channel from pingInterval

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,6 @@ e2e: dev-background
 e2e-ui: dev-background
 	npm install
 	cd e2e	
-	npm install
 	npx playwright test --ui
 	cd -
 	$(MAKE) dev-down

--- a/backend/api/buzzer.go
+++ b/backend/api/buzzer.go
@@ -60,7 +60,6 @@ func RegisterBuzzer(client *Client, event *Event) GameError {
 		return GameError{code: PLAYER_NOT_FOUND}
 	}
 	// Set up recurring ping loop to get player latency
-	clientPlayer.stopPing = make(chan bool)
 	go clientPlayer.pingInterval()
 	s.writeRoom(room.Game.Room, room)
 	return GameError{}

--- a/backend/api/hub.go
+++ b/backend/api/hub.go
@@ -36,7 +36,6 @@ func (h *Hub) run() {
 	defer func() {
 		for client := range h.clients {
 			client.conn.Close()
-			close(client.send)
 		}
 		close(h.register)
 		close(h.unregister)
@@ -49,14 +48,12 @@ func (h *Hub) run() {
 		case client := <-h.unregister:
 			if _, ok := h.clients[client]; ok {
 				delete(h.clients, client)
-				close(client.send)
 			}
 		case message := <-h.broadcast:
 			for client := range h.clients {
 				select {
 				case client.send <- message:
 				default:
-					close(client.send)
 					delete(h.clients, client)
 				}
 			}

--- a/backend/api/room.go
+++ b/backend/api/room.go
@@ -59,7 +59,8 @@ func (p *RegisteredClient) pingInterval() error {
 			if p.client.send != nil {
 				p.client.send <- message
 			}
-		case <-p.stopPing:
+		// Stop ping interval when client stops
+		case <-p.client.stop:
 			log.Println("Stop ping via channel", p.id)
 			return nil
 		}
@@ -102,7 +103,6 @@ type RegisteredClient struct {
 	id       string
 	client   *Client
 	room     *room
-	stopPing chan bool
 }
 
 type roomConnections struct {

--- a/backend/api/session.go
+++ b/backend/api/session.go
@@ -36,10 +36,6 @@ func quitPlayer(room *room, client *Client, event *Event) error {
 		}
 	}
 
-	if ok && playerClient.stopPing != nil {
-		// clear interval
-		playerClient.stopPing <- true
-	}
 	message, err := NewSendQuit()
 	if err != nil {
 		return fmt.Errorf(" %w", err)
@@ -177,15 +173,14 @@ func getBackInPlayer(client *Client, room room, roomCode string, playerID string
 
 	playerClient, ok := room.registeredClients[playerID]
 	if ok {
-		if playerClient.stopPing != nil {
-			playerClient.stopPing <- true
+		if playerClient.client.stop != nil {
+			playerClient.client.stop <- true
 		}
 	}
 	playerClient = &RegisteredClient{
 		id:       playerID,
 		client:   client,
 		room:     &room,
-		stopPing: make(chan bool),
 	}
 	go playerClient.pingInterval()
 	room.registeredClients[playerID] = playerClient

--- a/e2e/tests/game.spec.js
+++ b/e2e/tests/game.spec.js
@@ -8,6 +8,8 @@ test("quit button should return to home page", async ({ browser }) => {
   const host = await s.host();
   const spectator = await s.addPlayer(true);
   const gamePage = new GamePage(spectator.page);
-  await gamePage.quitButton.click();
+  await expect(async () => {
+    await gamePage.quitButton.click();
+  }).toPass();
   await expect(host.page).toHaveURL("/");
 });


### PR DESCRIPTION
- fix(backend): share the client.stop channel in pingInterval so that pingInterval will stop when the client is stopped preventing a chance to send to a closed channel on the next ticker interval

- fix(backend): Hub no longer closes client channels, because the client will still be open even if a user quits the game

- test(game): add expect block around flaky button click

- fix(make): remove deprecated `npm install` in e2e/ folder

Fixes: #191 