### PR TITLE
Websocket client and hub improvements

### DIFF
--- a/backend/api/client.go
+++ b/backend/api/client.go
@@ -123,7 +123,7 @@ func (c *Client) writePump() {
 }
 
 // ServeWs handles websocket requests from the peer.
-func ServeWs(w http.ResponseWriter, r *http.Request) {
+func ServeWs(hub *Hub, w http.ResponseWriter, r *http.Request) {
 	conn, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
 		log.Println(err)
@@ -132,8 +132,9 @@ func ServeWs(w http.ResponseWriter, r *http.Request) {
 	client := &Client{
 		conn: conn,
 		send: make(chan []byte, 256),
-		stop: make(chan bool),
+		stop: make(chan bool, 1),
 	}
+	hub.register <- client
 	// Allow collection of memory referenced by the caller by doing all work in
 	// new goroutines.
 	go client.writePump()

--- a/backend/api/session.go
+++ b/backend/api/session.go
@@ -124,7 +124,7 @@ func JoinRoom(client *Client, event *Event) GameError {
 func InitalizeRoom(client *Client, newRoomCode string) room {
 	initRoom := NewGame(newRoomCode)
 	initRoom.Hub = NewHub()
-	go initRoom.Hub.run()
+	go initRoom.Hub.Run()
 	go initRoom.gameTimeout()
 	initRoom.Hub.register <- client
 	return initRoom

--- a/backend/main.go
+++ b/backend/main.go
@@ -50,8 +50,11 @@ func main() {
 		log.Panicf("Error: unable initalize store: %s", err)
 	}
 
+	hub := api.NewHub()
+	go hub.Run()
+
 	http.HandleFunc("/api/ws", func(httpWriter http.ResponseWriter, httpRequest *http.Request) {
-		api.ServeWs(httpWriter, httpRequest)
+		api.ServeWs(hub, httpWriter, httpRequest)
 	})
 
 	http.HandleFunc("/api/health", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
some ideas to further improve websockets

- added hub parameter to `ServerWs` in `client.go` and made the stop channel buffered. This should help with client tracking and stopping
- renamed `run` to `Run` for `hub.go` and added a non-blocking stop signal when unregistering clients, it should prevent client leaks
- initialize hub in `ServerWs`  in `main.go`, 

- **fix(api): prevent client leaks, improve hub|**
