### PR TITLE
ALLOWED_ORIGINS environment variable

### DIFF
--- a/Dockerfile.allinone
+++ b/Dockerfile.allinone
@@ -8,7 +8,7 @@ COPY package-lock.json package.json /app/
 RUN npm install
 
 FROM golang:1.23.3-alpine AS back-end-builder
-ENV CGO_ENABLED 1
+ENV CGO_ENABLED=1
 RUN apk add gcc musl-dev sqlite
 WORKDIR /src
 COPY ./backend/ .

--- a/Dockerfile.allinone
+++ b/Dockerfile.allinone
@@ -17,6 +17,7 @@ RUN go build .
 FROM base AS app
 RUN apk add nginx bash
 WORKDIR /app
+ENV ALLOWED_ORIGINS="*"
 COPY --chmod=755 docker/allinone/start.sh /start.sh
 COPY ./games/ /app/games/
 COPY --from=back-end-builder /src/Cold-Friendly-Feud /app/Cold-Friendly-Feud

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,8 +1,8 @@
-FROM golang:1.23.3-alpine as base
+FROM golang:1.23.3-alpine AS base
 RUN mkdir -p /src
 WORKDIR /src
 
-FROM base as dev
+FROM base AS dev
 ENV CGO_ENABLED 1
 ENV GOCACHE=/src/.cache/go-build
 ENV GOMODCACHE=/src/.cache/go-mod
@@ -20,7 +20,7 @@ RUN apk add gcc musl-dev
 COPY . .
 RUN go build .
 
-FROM base as app
+FROM base AS app
 RUN mkdir -p /src
 WORKDIR /src
 COPY --from=games . /src/games/

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,7 +3,7 @@ RUN mkdir -p /src
 WORKDIR /src
 
 FROM base AS dev
-ENV CGO_ENABLED 1
+ENV CGO_ENABLED=1
 ENV GOCACHE=/src/.cache/go-build
 ENV GOMODCACHE=/src/.cache/go-mod
 RUN apk add gcc musl-dev sqlite curl
@@ -15,7 +15,7 @@ RUN mkdir -p .cache/go-build .cache/go-mod && \
 CMD ["air", "--build.cmd", "go build .", "--build.bin", "/src/Cold-Friendly-Feud"]
 
 FROM base AS builder
-ENV CGO_ENABLED 1
+ENV CGO_ENABLED=1
 RUN apk add gcc musl-dev
 COPY . .
 RUN go build .

--- a/backend/main.go
+++ b/backend/main.go
@@ -15,16 +15,19 @@ var cfg = struct {
 	addr               string
 	store              string
 	roomTimeoutSeconds int64
+	allowedOrigins     string
 }{
 	addr:               ":8080",
 	store:              "memory",
 	roomTimeoutSeconds: 86400,
+	allowedOrigins:     "*",
 }
 
 func flags() {
 	flag.StringVar(&cfg.addr, "listen_address", cfg.addr, "Address for server to bind to.")
 	flag.StringVar(&cfg.store, "game_store", cfg.store, "Choice of storage medium of the game")
 	flag.Int64Var(&cfg.roomTimeoutSeconds, "room_timeout_seconds", cfg.roomTimeoutSeconds, "Seconds before inactive rooms are cleaned up")
+	flag.StringVar(&cfg.allowedOrigins, "allowed_origins", cfg.allowedOrigins, "Comma-separated list of allowed origins for WebSocket connections or * for all")
 	flag.Parse()
 
 	if envAddr := os.Getenv("LISTEN_ADDRESS"); envAddr != "" {
@@ -40,11 +43,17 @@ func flags() {
 			cfg.roomTimeoutSeconds = timeout
 		}
 	}
+
+	if envOrigins := os.Getenv("ALLOWED_ORIGINS"); envOrigins != "" {
+		cfg.allowedOrigins = envOrigins
+	}
 }
 
 func main() {
 	flags()
 	api.SetConfig(cfg.roomTimeoutSeconds)
+	// Set allowed origins for WebSocket connections
+	os.Setenv("ALLOWED_ORIGINS", cfg.allowedOrigins)
 	err := api.NewGameStore(cfg.store)
 	if err != nil {
 		log.Panicf("Error: unable initalize store: %s", err)


### PR DESCRIPTION
Fixes #196 

- Defaults to `"*"`
- Separate by commas `ALLOWED_ORIGINS="https://example.com,https://app.example.com"`
- Deployment will have to be updated with `famf.app` origins @joshzcold 