### PR TITLE
Replace error div with error toasts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-i18next": "^15.4.0",
+        "sonner": "^2.0.1",
         "tailwindcss": "^3.1.0"
       },
       "devDependencies": {
@@ -6521,6 +6522,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.1.tgz",
+      "integrity": "sha512-FRBphaehZ5tLdLcQ8g2WOIRE+Y7BCfWi5Zyd8bCvBjiW8TxxAyoWZIxS661Yz6TGPqFQ4VLzOF89WEYhfynSFQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/sortobject": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-i18next": "^15.4.0",
+    "sonner": "^2.0.1",
     "tailwindcss": "^3.1.0"
   },
   "scripts": {
@@ -38,6 +39,7 @@
   },
   "devDependencies": {
     "@ianvs/prettier-plugin-sort-imports": "^4.4.0",
+    "@playwright/test": "^1.49.0",
     "@types/node": "22.10.5",
     "@types/react": "19.0.3",
     "@types/react-dom": "^19.0.2",
@@ -51,7 +53,6 @@
     "prettier": "^3.4.2",
     "prettier-plugin-tailwindcss": "^0.6.9",
     "tailwindcss-themer": "^4.1.1",
-    "typescript": "~5.1.6",
-    "@playwright/test": "^1.49.0"
+    "typescript": "~5.1.6"
   }
 }

--- a/src/components/Admin/GameLoader.jsx
+++ b/src/components/Admin/GameLoader.jsx
@@ -28,7 +28,6 @@ const GameLoader = ({ gameSelector, send, setError, setCsvFileUpload, setCsvFile
         pattern: /^application\/(json|.*\+json)$/,
         handler: (file) =>
           handleJsonFile(file, {
-            setError,
             t,
             send,
           }),

--- a/src/components/AdminPage.jsx
+++ b/src/components/AdminPage.jsx
@@ -14,6 +14,7 @@ import { debounce } from "@/lib/utils";
 import { FileUp } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
+import { toast } from "sonner";
 
 function TitleMusic() {
   const { i18n, t } = useTranslation();
@@ -222,7 +223,7 @@ function TitleLogoUpload(props) {
               if (file) {
                 if (file.size > process.env.NEXT_PUBLIC_MAX_IMAGE_UPLOAD_SIZE_MB * 1024 * 1024) {
                   console.error("Logo image is too large");
-                  props.setError(t(ERROR_CODES.IMAGE_TOO_LARGE, { message: "2MB" }));
+                  toast.error(t(ERROR_CODES.IMAGE_TOO_LARGE, { message: "2MB" }));
                   return;
                 }
                 var reader = new FileReader();
@@ -250,7 +251,7 @@ function TitleLogoUpload(props) {
                       mimetype = "jpeg";
                       break;
                     default:
-                      props.setError(t(ERROR_CODES.UNKNOWN_FILE_TYPE));
+                      toast.error(t(ERROR_CODES.UNKNOWN_FILE_TYPE));
                       return;
                   }
 
@@ -348,7 +349,6 @@ export default function AdminPage(props) {
     textColor: "text-foreground",
   });
   const [gameSelector, setGameSelector] = useState([]);
-  const [error, setErrorVal] = useState("");
   const [imageUploaded, setImageUploaded] = useState(null);
   const [timerStarted, setTimerStarted] = useState(false);
   const [timerCompleted, setTimerCompleted] = useState(false);
@@ -357,14 +357,6 @@ export default function AdminPage(props) {
   let ws = props.ws;
   let game = props.game;
   let refreshCounter = 0;
-
-  function setError(e) {
-    setErrorVal(e);
-    console.error(e);
-    setTimeout(() => {
-      setErrorVal("");
-    }, 10000);
-  }
 
   function send(data) {
     data.room = props.room;
@@ -376,7 +368,7 @@ export default function AdminPage(props) {
   useEffect(() => {
     const retryInterval = setInterval(() => {
       if (ws.current.readyState !== 1) {
-        setError(t(ERROR_CODES.CONNECTION_LOST, { message: `${5 - refreshCounter}` }));
+        toast.error(t(ERROR_CODES.CONNECTION_LOST, { message: `${5 - refreshCounter}` }));
         refreshCounter++;
         if (refreshCounter >= 10) {
           console.debug("admin reload()");
@@ -399,7 +391,7 @@ export default function AdminPage(props) {
         }
       } else if (json.action === "error") {
         console.error(json.code);
-        setError(t(json.code, { message: json.message }));
+        toast.error(t(json.code, { message: json.message }));
       } else if (json.action === "timer_complete") {
         setTimerStarted(false);
         setTimerCompleted(true);
@@ -484,7 +476,6 @@ export default function AdminPage(props) {
             <GameLoader
               gameSelector={gameSelector}
               send={send}
-              setError={setError}
               setCsvFileUpload={setCsvFileUpload}
               setCsvFileUploadText={setCsvFileUploadText}
             />
@@ -516,7 +507,6 @@ export default function AdminPage(props) {
               room={props.room}
               setGame={props.setGame}
               game={game}
-              setError={setError}
               setImageUploaded={setImageUploaded}
               imageUploaded={imageUploaded}
             />
@@ -581,9 +571,6 @@ export default function AdminPage(props) {
                 value={game.teams[1].points}
               ></input>
             </div>
-          </div>
-          <div id="errorText" className="whitespace-pre-wrap text-xl text-failure-700">
-            {error.code ? t(error.code, { message: error.message }) : t(error)}
           </div>
         </div>
         <hr className="my-12" />

--- a/src/components/BuzzerPage.jsx
+++ b/src/components/BuzzerPage.jsx
@@ -11,23 +11,16 @@ import cookieCutter from "cookie-cutter";
 import { EyeOff } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
+import { toast } from "sonner";
 
 let timerInterval = null;
 
 export default function BuzzerPage(props) {
   const { i18n, t } = useTranslation();
   const [buzzed, setBuzzed] = useState(false);
-  const [error, setErrorVal] = useState("");
   const [timer, setTimer] = useState(0);
   const [showMistake, setShowMistake] = useState(false);
   let refreshCounter = 0;
-
-  function setError(e) {
-    setErrorVal(e);
-    setTimeout(() => {
-      setErrorVal("");
-    }, 5000);
-  }
 
   let game = props.game;
   let ws = props.ws;
@@ -49,14 +42,12 @@ export default function BuzzerPage(props) {
     cookieCutter.set("session", `${props.room}:${props.id}:0`);
     setInterval(() => {
       if (ws.current.readyState !== 1) {
-        setError(t(ERROR_CODES.CONNECTION_LOST, { message: `${5 - refreshCounter}` }));
+        toast.error(t(ERROR_CODES.CONNECTION_LOST, { message: `${5 - refreshCounter}` }));
         refreshCounter++;
         if (refreshCounter >= 10) {
           console.debug("buzzer reload()");
           location.reload();
         }
-      } else {
-        setError("");
       }
     }, 1000);
 
@@ -192,7 +183,6 @@ export default function BuzzerPage(props) {
                     />
                   )}
                   <p className="p-2 italic text-secondary-900">{t("buzzer is reset between rounds")}</p>
-                  {error !== "" ? <p className="text-2xl text-failure-700">{error}</p> : null}
                 </div>
                 {/* END Buzzer Section TODO replace with function*/}
                 <div className="flex min-w-full flex-row justify-between space-x-3">
@@ -340,7 +330,6 @@ export default function BuzzerPage(props) {
                 </button>
               </Link>
             </div>
-            {error != null && error !== "" ? <p>👾 {error}</p> : null}
           </>
         )}
       </>

--- a/src/components/LoginPage.jsx
+++ b/src/components/LoginPage.jsx
@@ -6,33 +6,26 @@ import { useTranslation } from "react-i18next";
 import "@/i18n/i18n";
 import ThemeSwitcher from "@/components/Admin/ThemeSwitcher";
 import { ERROR_CODES } from "@/i18n/errorCodes";
+import { toast } from "sonner";
 
 export default function LoginPage(props) {
   const { t } = useTranslation();
   const { theme } = useTheme();
   const [playerName, setPlayerName] = useState("");
   const [roomCode, setRoomCode] = useState("");
-  const [error, setErrorVal] = useState("");
   const [game, setGame] = useState({ settings: { theme: theme || "default" } });
-
-  function setError(e) {
-    setErrorVal(e);
-    setTimeout(() => {
-      setErrorVal("");
-    }, 5000);
-  }
 
   const isValidRoomCode = (code) => code.length === 4;
   const isValidPlayerName = (name) => name.length > 0 && name.length <= 12;
 
   const handlePlay = () => {
     if (!isValidPlayerName(playerName)) {
-      setError(t(ERROR_CODES.MISSING_INPUT, { message: t("name") }));
+      toast.error(t(ERROR_CODES.MISSING_INPUT, { message: t("name") }));
       return;
     }
 
     if (!isValidRoomCode(roomCode)) {
-      setError(t("room code is not correct length, should be 4 characters"));
+      toast.error(t("room code is not correct length, should be 4 characters"));
       return;
     }
 
@@ -40,8 +33,6 @@ export default function LoginPage(props) {
     props.setPlayerName(playerName);
     props.joinRoom();
   };
-
-  const displayError = props.error || error;
 
   return (
     <div className={`flex min-h-screen w-full flex-col space-y-10 bg-background p-5`}>
@@ -96,11 +87,6 @@ export default function LoginPage(props) {
           {t("host")}
         </button>
       </div>
-      {displayError !== "" ? (
-        <p id="errorText" className="text-2xl text-failure-700">
-          {displayError.code ? t(displayError.code, { message: displayError.message }) : t(displayError)}
-        </p>
-      ) : null}
     </div>
   );
 }

--- a/src/components/ToasterWithTheme.jsx
+++ b/src/components/ToasterWithTheme.jsx
@@ -1,0 +1,21 @@
+import { useTheme } from "next-themes";
+import { Toaster } from "sonner";
+
+function ToasterWithTheme({ ...props }) {
+  const { theme } = useTheme();
+
+  // Map custom theme names to "light" or "dark" for Sonner
+  const themeMap = {
+    default: "light",
+    darkTheme: "dark",
+    slate: "dark",
+    educational: "light",
+    red: "dark",
+  };
+
+  const sonnerTheme = themeMap[theme] || "light";
+
+  return <Toaster theme={sonnerTheme} richColors {...props} />;
+}
+
+export default ToasterWithTheme;

--- a/src/lib/utils/files.js
+++ b/src/lib/utils/files.js
@@ -1,4 +1,6 @@
-export function handleJsonFile(file, { setError, t, send }) {
+import { toast } from "sonner";
+
+export function handleJsonFile(file, { t, send }) {
   var reader = new FileReader();
   reader.readAsText(file, "utf-8");
   reader.onload = function (evt) {
@@ -7,19 +9,19 @@ export function handleJsonFile(file, { setError, t, send }) {
       let errors = validateGameData(data, { t });
 
       if (errors.length > 0) {
-        setError(t("Game file error") + ":\n" + errors.join("\n"));
+        toast.error(t("Game file error") + ":\n" + errors.join("\n"));
         return;
       }
       console.debug(data);
       send({ action: "load_game", data: data });
     } catch (e) {
       console.error("Invalid JSON file", e);
-      setError(t(`Invalid JSON file: ${e}`));
+      toast.error(t(`Invalid JSON file: ${e}`));
     }
   };
   reader.onerror = function (evt) {
     console.error("error reading file");
-    setError(t("error reading file"));
+    toast.error(t("error reading file"));
   };
 }
 

--- a/src/pages/_app.jsx
+++ b/src/pages/_app.jsx
@@ -1,7 +1,8 @@
-import '../global.css'
-import ThemeProvider from '@/components/ThemeProvider'
-import Head from 'next/head'
-import Script from 'next/script'
+import "../global.css";
+import ThemeProvider from "@/components/ThemeProvider";
+import ToasterWithTheme from "@/components/ToasterWithTheme";
+import Head from "next/head";
+import Script from "next/script";
 
 // This default export is required in a new `pages/_app.js` file.
 export default function MyApp({ Component, pageProps }) {
@@ -32,16 +33,20 @@ export default function MyApp({ Component, pageProps }) {
         {/* Prevent unloaded theme on page refresh causing white flash if dark theme */}
       </Head>
       <Script
-      id='theme-loader'
+        id="theme-loader"
         dangerouslySetInnerHTML={{
           __html: `
           var theme = localStorage.getItem('theme') || 'default'
           document.documentElement.classList.add(theme)
-        `
-      }} />
+        `,
+        }}
+      />
       <ThemeProvider>
+        <div>
+          <ToasterWithTheme />
+        </div>
         <Component {...pageProps} />
       </ThemeProvider>
     </>
-  )
+  );
 }

--- a/src/pages/game.jsx
+++ b/src/pages/game.jsx
@@ -9,6 +9,7 @@ import cookieCutter from "cookie-cutter";
 import Image from "next/image";
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
 
 let timerInterval = null;
 
@@ -16,7 +17,6 @@ export default function Game(props) {
   const { i18n, t } = useTranslation();
   const [game, setGame] = useState({});
   const [timer, setTimer] = useState(0);
-  const [error, setErrorVal] = useState("");
   const [showMistake, setShowMistake] = useState(false);
   const [isHost, setIsHost] = useState(false);
   const [buzzed, setBuzzed] = useState({});
@@ -29,13 +29,6 @@ export default function Game(props) {
       setTimer(game.final_round_timers[timerIndex]);
     }
   }, [game.is_final_round, game.is_final_second]);
-
-  function setError(e) {
-    setErrorVal(e);
-    setTimeout(() => {
-      setErrorVal("");
-    }, 5000);
-  }
 
   useEffect(() => {
     ws.current = new WebSocket(`wss://${window.location.host}/api/ws`);
@@ -179,14 +172,12 @@ export default function Game(props) {
 
     setInterval(() => {
       if (ws.current.readyState !== 1) {
-        setError(t(ERROR_CODES.CONNECTION_LOST, { message: `${5 - refreshCounter}` }));
+        toast.error(t(ERROR_CODES.CONNECTION_LOST, { message: `${5 - refreshCounter}` }));
         refreshCounter++;
         if (refreshCounter >= 5) {
           console.debug("game reload()");
           location.reload();
         }
-      } else {
-        setError("");
       }
     }, 1000);
   }, []);
@@ -248,10 +239,7 @@ export default function Game(props) {
           />
         </div>
         <div className={`${game?.settings?.theme} min-h-screen`}>
-          <div className="">
-            {gameSession}
-            {error !== "" ? <p className="text-2xl text-failure-700">{error}</p> : null}
-          </div>
+          <div className="">{gameSession}</div>
         </div>
         <BuzzerPopup buzzed={buzzed} />
       </>

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -8,12 +8,12 @@ import Footer from "@/components/Login/Footer";
 import LoginPage from "@/components/LoginPage";
 import { ERROR_CODES } from "@/i18n/errorCodes";
 import cookieCutter from "cookie-cutter";
+import { toast } from "sonner";
 
 export default function Home() {
   const { t } = useTranslation();
   const [playerName, setPlayerName] = useState("");
   const [roomCode, setRoomCode] = useState("");
-  const [error, setErrorVal] = useState("");
   const [registeredRoomCode, setRegisteredRoomCode] = useState(null);
   const [host, setHost] = useState(false);
   const [game, setGame] = useState(null);
@@ -22,12 +22,6 @@ export default function Home() {
 
   const ws = useRef(null);
 
-  function setError(e) {
-    setErrorVal(e);
-    setTimeout(() => {
-      setErrorVal("");
-    }, 5000);
-  }
   /**
    * send quit message to server
    * server cleans up data on backend then
@@ -86,7 +80,7 @@ export default function Home() {
           setGame(json.game);
         } else if (json.action === "error") {
           console.error(json);
-          setError(t(json.code, { message: json.message }));
+          toast.error(t(json.code, { message: json.message }));
         } else if (json.action === "ping") {
           console.debug("index.js: ping");
         } else {
@@ -110,7 +104,7 @@ export default function Home() {
         console.debug("wait for connection...");
         tries++;
         if (tries > 30) {
-          setError(t(ERROR_CODES.UNABLE_TO_CONNECT));
+          toast.error(t(ERROR_CODES.UNABLE_TO_CONNECT));
           return;
         }
         waitForSocketConnection(socket, callback, tries);
@@ -165,7 +159,6 @@ export default function Home() {
    */
   function joinRoom() {
     console.debug(`ws.current `, ws);
-    setError("");
     let roomcode = document.getElementById("roomCodeInput").value;
     if (roomcode.length === 4) {
       let playername = document.getElementById("playerNameInput").value;
@@ -179,10 +172,10 @@ export default function Home() {
           })
         );
       } else {
-        setError(t(ERROR_CODES.MISSING_INPUT, { message: t("name") }));
+        toast.error(t(ERROR_CODES.MISSING_INPUT, { message: t("name") }));
       }
     } else {
-      setError(t("room code is not correct length, should be 4 characters"));
+      toast.error(t("room code is not correct length, should be 4 characters"));
     }
   }
 
@@ -231,7 +224,6 @@ export default function Home() {
               playerName={playerName}
               joinRoom={joinRoom}
               hostRoom={hostRoom}
-              error={error}
             />
           </div>
           <Footer />


### PR DESCRIPTION
Fixes #180

This is a very simple fix and should make errors more consistent across the page as well. Replaces the repeated error state across the pages with the [sonner](https://sonner.emilkowal.ski/) component

![NVIDIA_Overlay_ek5ptvZZly](https://github.com/user-attachments/assets/9c10cd0d-d390-453c-9b18-9524794c216e)

- **chore(dependencies): add sonner package**
- **feat(ui): add theme-aware Sonner toast component**
- **feat(ui): add ToasterWithTheme component into app layout**
- **refactor(LoginPage): replace error state with Sonner toast notifications**
- **refactor(Home): replace error handling with Sonner toast notifications**
- **refactor(AdminPage): replace error handling with Sonner toast notifications**
- **refactor(BuzzerPage): replace error state with Sonner toast notifications**
- **refactor(GameLoader): replace setError with Sonner toast notifications for error handling**
- **refactor(Game): replace error state with Sonner toast**
