### PR TITLE
fix(ui): Mistake image uses the .png to make sure it looks correct

### DIFF
--- a/src/components/AdminPage.jsx
+++ b/src/components/AdminPage.jsx
@@ -719,7 +719,7 @@ export default function AdminPage(props) {
                     send({ action: "show_mistake" });
                   }}
                 >
-                  <Image width={150} height={150} style={{ objectFit: "contain" }} src="/x.svg" alt="Show Mistake" />
+                  <Image width={150} height={150} style={{ objectFit: "contain" }} src="/x.png" alt="Show Mistake" />
                 </button>
                 <button
                   id="resetMistakesButton"

--- a/src/components/BuzzerPage.jsx
+++ b/src/components/BuzzerPage.jsx
@@ -132,7 +132,7 @@ export default function BuzzerPage(props) {
             className={`pointer-events-none fixed inset-0 z-50 p-24 ${
               showMistake ? "opacity-90" : "opacity-0"
             } transition-opacity duration-300 ease-in-out`}
-            src="/x.svg"
+            src="/x.png"
             alt="Mistake indicator"
             aria-hidden={!showMistake}
           />

--- a/src/pages/game.jsx
+++ b/src/pages/game.jsx
@@ -233,7 +233,7 @@ export default function Game(props) {
             className={`pointer-events-none fixed inset-0 z-50 p-24 ${
               showMistake ? "opacity-90" : "opacity-0"
             } transition-opacity duration-300 ease-in-out`}
-            src="/x.svg"
+            src="/x.png"
             alt="Mistake indicator"
             aria-hidden={!showMistake}
           />


### PR DESCRIPTION
instead of relying on fonts for the .svg, we can use the .png to be correct always

Fixes: #200